### PR TITLE
Fix the return value when inc operation fails, but ignoreFailures=true

### DIFF
--- a/index.js
+++ b/index.js
@@ -421,7 +421,7 @@ _.extend(LocalDb.prototype, Backbone.Events, {
       });
     } else {
       if (options.ignoreFailures) {
-        return cb(null, model);
+        return cb(null, {});
       }
       var errorMsg = util.format('%s (%s), cannot INC', model.type, model.id);
       return cb(new errors.NotFoundError(errorMsg));


### PR DESCRIPTION
There should be a JSON of model data, but we don't necessarily have all attributes on the model, and `toJSON` is not equivalent to the actual database data due to virtual properties and relations. So returning an empty object seems like the lesser evil.